### PR TITLE
Add Dockerfile and bump nodejs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Using mhart/alpine-node instead of node:0.10
+# because of more up to date dependencies
+# (node:0.10 has a two year old Debian Jessie Image)
+# and much smaller footprint
+FROM mhart/alpine-node:0.10
+
+ENV PORT=8080
+WORKDIR /app
+COPY . /app
+RUN set -e; apk update; apk upgrade; npm install
+
+CMD node app.js
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-# Using mhart/alpine-node instead of node:0.10
-# because of more up to date dependencies
-# (node:0.10 has a two year old Debian Jessie Image)
-# and much smaller footprint
-FROM mhart/alpine-node:0.10
+FROM node:8-alpine
 
 ENV PORT=8080
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8-alpine
 ENV PORT=8080
 WORKDIR /app
 COPY . /app
-RUN set -e; apk update; apk upgrade; yarn install
+RUN set -e; apk upgrade --no-cache; yarn install
 
 CMD node app.js
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8-alpine
 ENV PORT=8080
 WORKDIR /app
 COPY . /app
-RUN set -e; apk update; apk upgrade; npm install
+RUN set -e; apk update; apk upgrade; yarn install
 
 CMD node app.js
 EXPOSE 8080

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "devDependencies": {},
   "optionalDependencies": {},
   "engines": {
-    "node": "0.10.x"
+    "node": "8.x"
   }
 }


### PR DESCRIPTION
Just experimenting with Dockerfiles and other peoples code, feel free to merge.
I'm also bumping the nodejs version to the latest LTS release.
Also tried bumping express and sockets to their latest version, which makes the latency test still work - but breaks the numbers on top so it breaks `Min: ? Max: 73 Average: 38`.